### PR TITLE
fix: fix eslint, vscode config & update `yarn.lock`

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -17,7 +17,8 @@
       "jsx": true
     },
     "ecmaVersion": "latest",
-    "sourceType": "module"
+    "sourceType": "module",
+    "project": ["tsconfig.json"]
   },
   "plugins": ["react", "@typescript-eslint", "prettier"],
   "rules": {

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ dist-ssr
 # Editor directories and files
 .vscode/*
 !.vscode/extensions.json
+!.vscode/settings.json
 .idea
 .DS_Store
 *.suo

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,10 @@
+{
+  "editor.tabSize": 2,
+  "editor.formatOnSave": true,
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
+  "git.pruneOnFetch": true,
+  "typescript.tsdk": "node_modules/typescript/lib",
+  "editor.codeActionsOnSave": {
+    "source.fixAll.eslint": true
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -9069,7 +9069,7 @@ store2@^2.14.2:
   resolved "https://registry.yarnpkg.com/store2/-/store2-2.14.2.tgz#56138d200f9fe5f582ad63bc2704dbc0e4a45068"
   integrity sha512-siT1RiqlfQnGqgT/YzXVUNsom9S0H1OX+dpdGN1xkyYATo4I6sep5NmsRD/40s3IIOvlCq6akxkqG82urIZW1w==
 
-storybook-addon-react-router-v6@^1.0.2:
+storybook-addon-react-router-v6@1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/storybook-addon-react-router-v6/-/storybook-addon-react-router-v6-1.0.2.tgz#0f1239de31291821c93e8266079b8f6235a9c717"
   integrity sha512-38W+9D2sIrYAi+oRSbsLhR/umNoLVw2DWF84Jp4f/ZoB8Cg0Qtbvwk043oHqzNOpZrfgj0FaV006oaJBVpE8Kw==


### PR DESCRIPTION
## 🔗 Issue Number
None

## 📄 Description
- ESLint가 VSCode에서 제대로 작동하지 않는 문제를 해결했습니다. (`You have used a rule which requires parserServices to be generated.`)
- 일부 VSCode 설정을 프로젝트 단위로 공유하도록 업로드했습니다.
- `yarn.lock`의 일부 잘못된 부분을 업데이트했습니다.

## ✅ Checklist

- [x] PR 제목을 commit 규칙에 맞게 작성했나요?
- [x] label을 설정했나요?
- [x] 작업한 사람 모두를 Assign 했나요?
- [x] Code Review를 요청 했나요?
