### PR TITLE
feat: add skeleton calendar components

### DIFF
--- a/src/components/common/Calendar/Day.tsx
+++ b/src/components/common/Calendar/Day.tsx
@@ -1,0 +1,32 @@
+import { memo, useMemo } from 'react';
+import { getDateOfWeek } from '@/utils/date';
+
+interface RenderDayProps {
+  date: Date;
+  /** 직접 props로 넣은 `month`와 실제 `date`의 달이 일치하는지를 나타내는 변수 */
+  isInCurrentMonth: boolean;
+}
+
+export type RenderDay = (props: RenderDayProps) => JSX.Element;
+
+interface DayProps {
+  renderDay: RenderDay;
+  year: number;
+  month: number;
+  /** 0~5 */
+  week: number;
+  /** 0~6 */
+  dayIndex: number;
+}
+
+const Day = ({ renderDay, year, month, week, dayIndex }: DayProps) => {
+  const date = useMemo(
+    () => getDateOfWeek(year, month, week, dayIndex),
+    [year, month, week, dayIndex],
+  );
+  const isInCurrentMonth = date.getMonth() === month;
+
+  return renderDay({ date, isInCurrentMonth });
+};
+
+export default memo(Day);

--- a/src/components/common/Calendar/Day.tsx
+++ b/src/components/common/Calendar/Day.tsx
@@ -1,7 +1,7 @@
 import { memo, useMemo } from 'react';
 import { getDateOfWeek } from '@/utils/date';
 
-interface RenderDayProps {
+export interface RenderDayProps {
   date: Date;
   /** 직접 props로 넣은 `month`와 실제 `date`의 달이 일치하는지를 나타내는 변수 */
   isInCurrentMonth: boolean;

--- a/src/components/common/Calendar/Month.stories.tsx
+++ b/src/components/common/Calendar/Month.stories.tsx
@@ -1,0 +1,72 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { type RenderWeek } from './Week';
+import { type RenderDay } from './Day';
+import Month, { type RenderMonth } from './Month';
+
+const renderMonth: RenderMonth = ({ year, month, children }) => (
+  <div style={{ display: 'flex', flexDirection: 'column' }}>
+    <p>
+      {year}년 {month + 1}월
+    </p>
+    {children}
+  </div>
+);
+
+const renderWeek: RenderWeek = ({
+  year,
+  month,
+  week,
+  isFirstWeek,
+  isLastWeek,
+  children,
+}) => (
+  <div style={{ display: 'flex', flexDirection: 'column' }}>
+    <p>
+      {year}년 {month + 1}월 {week + 1}번째 주
+    </p>
+    <p>
+      isFirstWeek: {isFirstWeek ? 'true' : 'false'}, isLastWeek:{' '}
+      {isLastWeek ? 'true' : 'false'}
+    </p>
+    <div style={{ display: 'flex', flexDirection: 'row' }}>{children}</div>
+  </div>
+);
+
+const renderDay: RenderDay = ({ date, isInCurrentMonth }) => (
+  <div
+    style={{
+      width: '100px',
+      height: '100px',
+      border: '1px solid #000000',
+      display: 'flex',
+      flexDirection: 'column',
+      alignItems: 'center',
+      justifyContent: 'center',
+      color: isInCurrentMonth ? '#000000' : '#b9b9b9',
+    }}
+  >
+    <p>
+      {date.getFullYear()}-{date.getMonth() + 1}-{date.getDate()}
+    </p>
+  </div>
+);
+
+const meta: Meta<typeof Month> = {
+  component: Month,
+  args: {
+    renderDay,
+    renderWeek,
+    renderMonth,
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Month>;
+
+export const General: Story = {
+  args: {
+    year: 2023,
+    month: 6,
+  },
+};

--- a/src/components/common/Calendar/Month.stories.tsx
+++ b/src/components/common/Calendar/Month.stories.tsx
@@ -19,6 +19,7 @@ const renderWeek: RenderWeek = ({
   week,
   isFirstWeek,
   isLastWeek,
+  isInCurrentMonth,
   children,
 }) => (
   <div style={{ display: 'flex', flexDirection: 'column' }}>
@@ -27,7 +28,8 @@ const renderWeek: RenderWeek = ({
     </p>
     <p>
       isFirstWeek: {isFirstWeek ? 'true' : 'false'}, isLastWeek:{' '}
-      {isLastWeek ? 'true' : 'false'}
+      {isLastWeek ? 'true' : 'false'}, isInCurrentMonth:{' '}
+      {isInCurrentMonth ? 'true' : 'false'}
     </p>
     <div style={{ display: 'flex', flexDirection: 'row' }}>{children}</div>
   </div>

--- a/src/components/common/Calendar/Month.stories.tsx
+++ b/src/components/common/Calendar/Month.stories.tsx
@@ -1,8 +1,13 @@
 import type { Meta, StoryObj } from '@storybook/react';
 
+import { type MutableRefObject, useCallback, useRef } from 'react';
 import { type RenderWeek } from './Week';
-import { type RenderDay } from './Day';
+import { type RenderDayProps, type RenderDay } from './Day';
 import Month, { type RenderMonth } from './Month';
+import useCalendarState, {
+  useSetCalendarState,
+  withCalendarStateProvider,
+} from '@/hooks/useCalendarState';
 
 const renderMonth: RenderMonth = ({ year, month, children }) => (
   <div style={{ display: 'flex', flexDirection: 'column' }}>
@@ -54,10 +59,87 @@ const renderDay: RenderDay = ({ date, isInCurrentMonth }) => (
   </div>
 );
 
+type DayInfo = {
+  isSelected: boolean;
+};
+
+interface DayWithCalendarStateProps extends RenderDayProps {
+  selectedDayRef: MutableRefObject<Date | null>;
+}
+
+function DayWithCalendarState({
+  date,
+  isInCurrentMonth,
+  selectedDayRef,
+}: DayWithCalendarStateProps) {
+  const [dayState, setDayState] = useCalendarState<DayInfo>({
+    type: 'day',
+    date,
+  });
+  const setCalendarState = useSetCalendarState<DayInfo>();
+
+  // 날짜를 선택할 때 콘솔이 최대 2번(기존에 선택되어 있던 날짜 한 번, 새로 선택한 날짜 한 번)만 찍히는지 확인
+  console.log(
+    `day re-rendered, ${date.getFullYear()}-${
+      date.getMonth() + 1
+    }-${date.getDate()}`,
+  );
+
+  return (
+    /* eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions */
+    <div
+      style={{
+        width: '100px',
+        height: '100px',
+        border: '1px solid #000000',
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        justifyContent: 'center',
+        color: isInCurrentMonth ? '#000000' : '#b9b9b9',
+        backgroundColor: dayState?.isSelected ? '#ffa2a2' : 'transparent',
+      }}
+      onClick={() => {
+        if (selectedDayRef.current === null) {
+          setDayState((prev) => ({ ...prev, isSelected: true }));
+          // eslint-disable-next-line no-param-reassign
+          selectedDayRef.current = date;
+        } else if (
+          selectedDayRef.current.getFullYear() === date.getFullYear() &&
+          selectedDayRef.current.getMonth() === date.getMonth() &&
+          selectedDayRef.current.getDate() === date.getDate()
+        ) {
+          setDayState((prev) => ({ ...prev, isSelected: false }));
+          // eslint-disable-next-line no-param-reassign
+          selectedDayRef.current = null;
+        } else {
+          setCalendarState(
+            {
+              type: 'day',
+              date: selectedDayRef.current,
+              newData: (prev) => ({ ...prev, isSelected: false }),
+            },
+            {
+              type: 'day',
+              date,
+              newData: (prev) => ({ ...prev, isSelected: true }),
+            },
+          );
+          // eslint-disable-next-line no-param-reassign
+          selectedDayRef.current = date;
+        }
+      }}
+    >
+      <p>
+        {date.getFullYear()}-{date.getMonth() + 1}-{date.getDate()}
+      </p>
+    </div>
+  );
+}
+
 const meta: Meta<typeof Month> = {
   component: Month,
   args: {
-    renderDay,
     renderWeek,
     renderMonth,
   },
@@ -68,7 +150,36 @@ type Story = StoryObj<typeof Month>;
 
 export const General: Story = {
   args: {
+    renderDay,
     year: 2023,
     month: 6,
   },
+};
+
+export const MonthWithCalendarState: Story = {
+  args: {
+    year: 2023,
+    month: 6,
+  },
+  render: withCalendarStateProvider(({ ...props }) => {
+    const selectedDayRef = useRef<Date | null>(null);
+    const renderDayWithCalendarState = useCallback(
+      (renderDayProps: RenderDayProps) => (
+        <DayWithCalendarState
+          /* eslint-disable-next-line react/jsx-props-no-spreading */
+          {...renderDayProps}
+          selectedDayRef={selectedDayRef}
+        />
+      ),
+      [],
+    );
+
+    return (
+      <div>
+        <h2>날짜를 누르면 배경색이 칠해집니다.</h2>
+        {/* eslint-disable-next-line react/jsx-props-no-spreading */}
+        <Month {...props} renderDay={renderDayWithCalendarState} />
+      </div>
+    );
+  }),
 };

--- a/src/components/common/Calendar/Month.tsx
+++ b/src/components/common/Calendar/Month.tsx
@@ -1,0 +1,48 @@
+import { memo, type ReactNode } from 'react';
+import { type RenderDay } from './Day';
+import Week, { type RenderWeek } from './Week';
+
+interface RenderMonthProps {
+  year: number;
+  /** 0~11 */
+  month: number;
+  children: ReactNode;
+}
+
+export type RenderMonth = (props: RenderMonthProps) => JSX.Element;
+
+interface MonthProps {
+  renderMonth: RenderMonth;
+  renderWeek: RenderWeek;
+  renderDay: RenderDay;
+  year: number;
+  /** 0~11 */
+  month: number;
+}
+
+const WEEKS = [0, 1, 2, 3, 4, 5] as const;
+
+function Month({
+  renderMonth: CustomMonth,
+  renderWeek,
+  renderDay,
+  year,
+  month,
+}: MonthProps) {
+  return (
+    <CustomMonth year={year} month={month}>
+      {WEEKS.map((week) => (
+        <Week
+          key={week}
+          renderWeek={renderWeek}
+          renderDay={renderDay}
+          year={year}
+          month={month}
+          week={week}
+        />
+      ))}
+    </CustomMonth>
+  );
+}
+
+export default memo(Month);

--- a/src/components/common/Calendar/Month.tsx
+++ b/src/components/common/Calendar/Month.tsx
@@ -2,7 +2,7 @@ import { memo, type ReactNode } from 'react';
 import { type RenderDay } from './Day';
 import Week, { type RenderWeek } from './Week';
 
-interface RenderMonthProps {
+export interface RenderMonthProps {
   year: number;
   /** 0~11 */
   month: number;

--- a/src/components/common/Calendar/Week.stories.tsx
+++ b/src/components/common/Calendar/Week.stories.tsx
@@ -9,6 +9,7 @@ const renderWeek: RenderWeek = ({
   week,
   isFirstWeek,
   isLastWeek,
+  isInCurrentMonth,
   children,
 }) => (
   <div style={{ display: 'flex', flexDirection: 'column' }}>
@@ -17,7 +18,8 @@ const renderWeek: RenderWeek = ({
     </p>
     <p>
       isFirstWeek: {isFirstWeek ? 'true' : 'false'}, isLastWeek:{' '}
-      {isLastWeek ? 'true' : 'false'}
+      {isLastWeek ? 'true' : 'false'}, isInCurrentMonth:{' '}
+      {isInCurrentMonth ? 'true' : 'false'}
     </p>
     <div style={{ display: 'flex', flexDirection: 'row' }}>{children}</div>
   </div>
@@ -82,5 +84,13 @@ export const FirstAndLastWeek: Story = {
     year: 2023,
     month: 6,
     week: 0,
+  },
+};
+
+export const NotInCurrentMonth: Story = {
+  args: {
+    year: 2023,
+    month: 7,
+    week: 5,
   },
 };

--- a/src/components/common/Calendar/Week.stories.tsx
+++ b/src/components/common/Calendar/Week.stories.tsx
@@ -1,0 +1,86 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import Week, { type RenderWeek } from './Week';
+import { type RenderDay } from './Day';
+
+const renderWeek: RenderWeek = ({
+  year,
+  month,
+  week,
+  isFirstWeek,
+  isLastWeek,
+  children,
+}) => (
+  <div style={{ display: 'flex', flexDirection: 'column' }}>
+    <p>
+      {year}년 {month + 1}월 {week + 1}번째 주
+    </p>
+    <p>
+      isFirstWeek: {isFirstWeek ? 'true' : 'false'}, isLastWeek:{' '}
+      {isLastWeek ? 'true' : 'false'}
+    </p>
+    <div style={{ display: 'flex', flexDirection: 'row' }}>{children}</div>
+  </div>
+);
+
+const renderDay: RenderDay = ({ date, isInCurrentMonth }) => (
+  <div
+    style={{
+      width: '100px',
+      height: '100px',
+      border: '1px solid #000000',
+      display: 'flex',
+      flexDirection: 'column',
+      alignItems: 'center',
+      justifyContent: 'center',
+      color: isInCurrentMonth ? '#000000' : '#b9b9b9',
+    }}
+  >
+    <p>
+      {date.getFullYear()}-{date.getMonth() + 1}-{date.getDate()}
+    </p>
+  </div>
+);
+
+const meta: Meta<typeof Week> = {
+  component: Week,
+  args: {
+    renderDay,
+    renderWeek,
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Week>;
+
+export const General: Story = {
+  args: {
+    year: 2023,
+    month: 6,
+    week: 1,
+  },
+};
+
+export const FirstWeek: Story = {
+  args: {
+    year: 2023,
+    month: 9,
+    week: 0,
+  },
+};
+
+export const LastWeek: Story = {
+  args: {
+    year: 2023,
+    month: 8,
+    week: 4,
+  },
+};
+
+export const FirstAndLastWeek: Story = {
+  args: {
+    year: 2023,
+    month: 6,
+    week: 0,
+  },
+};

--- a/src/components/common/Calendar/Week.tsx
+++ b/src/components/common/Calendar/Week.tsx
@@ -13,6 +13,8 @@ interface RenderWeekProps {
   isFirstWeek: boolean;
   /** 이번 달 또는 다음 달 또는 이전 달 중 하나의 마지막 주인지를 나타냄 */
   isLastWeek: boolean;
+  /** 직접 props로 넣은 `month`에 해당하는 날짜가 적어도 하나 포함된 주인지를 나타냄 */
+  isInCurrentMonth: boolean;
   children: ReactNode;
 }
 
@@ -58,6 +60,8 @@ function Week({
     lastDateOfWeek.getMonth() !== lastDateOfPrevWeek.getMonth();
   const isLastWeek =
     firstDateOfWeek.getMonth() !== firstDateOfNextWeek.getMonth();
+  const isInCurrentMonth =
+    firstDateOfWeek.getMonth() === month || lastDateOfWeek.getMonth() === month;
 
   return (
     <CustomWeek
@@ -66,6 +70,7 @@ function Week({
       week={week}
       isFirstWeek={isFirstWeek}
       isLastWeek={isLastWeek}
+      isInCurrentMonth={isInCurrentMonth}
     >
       {DAYS.map((dayIndex) => (
         <Day

--- a/src/components/common/Calendar/Week.tsx
+++ b/src/components/common/Calendar/Week.tsx
@@ -2,7 +2,7 @@ import { useMemo, type ReactNode, memo } from 'react';
 import Day, { type RenderDay } from './Day';
 import { getDateOfWeek } from '@/utils/date';
 
-interface RenderWeekProps {
+export interface RenderWeekProps {
   /** props로 넣어준 `year`와 동일한 값 */
   year: number;
   /** props로 넣어준 `month`와 동일한 값. 0~11 */

--- a/src/components/common/Calendar/Week.tsx
+++ b/src/components/common/Calendar/Week.tsx
@@ -1,0 +1,84 @@
+import { useMemo, type ReactNode, memo } from 'react';
+import Day, { type RenderDay } from './Day';
+import { getDateOfWeek } from '@/utils/date';
+
+interface RenderWeekProps {
+  /** props로 넣어준 `year`와 동일한 값 */
+  year: number;
+  /** props로 넣어준 `month`와 동일한 값. 0~11 */
+  month: number;
+  /** props로 넣어준 `week`와 동일한 값. 0~5 */
+  week: number;
+  /** 이번 달 또는 다음 달 또는 이전 달 중 하나의 첫째 주인지를 나타냄 */
+  isFirstWeek: boolean;
+  /** 이번 달 또는 다음 달 또는 이전 달 중 하나의 마지막 주인지를 나타냄 */
+  isLastWeek: boolean;
+  children: ReactNode;
+}
+
+export type RenderWeek = (props: RenderWeekProps) => JSX.Element;
+
+interface WeekProps {
+  renderWeek: RenderWeek;
+  renderDay: RenderDay;
+  /** 4자리 full year */
+  year: number;
+  /** 0~11 */
+  month: number;
+  /** 0~5, overflow 가능 */
+  week: number;
+}
+
+const DAYS = [0, 1, 2, 3, 4, 5, 6] as const;
+
+function Week({
+  renderWeek: CustomWeek,
+  renderDay,
+  year,
+  month,
+  week,
+}: WeekProps) {
+  const firstDateOfWeek = useMemo(
+    () => getDateOfWeek(year, month, week, 0),
+    [year, month, week],
+  );
+  const lastDateOfWeek = useMemo(
+    () => getDateOfWeek(year, month, week, 6),
+    [year, month, week],
+  );
+  const lastDateOfPrevWeek = useMemo(
+    () => getDateOfWeek(year, month, week - 1, 6),
+    [year, month, week],
+  );
+  const firstDateOfNextWeek = useMemo(
+    () => getDateOfWeek(year, month, week + 1, 0),
+    [year, month, week],
+  );
+  const isFirstWeek =
+    lastDateOfWeek.getMonth() !== lastDateOfPrevWeek.getMonth();
+  const isLastWeek =
+    firstDateOfWeek.getMonth() !== firstDateOfNextWeek.getMonth();
+
+  return (
+    <CustomWeek
+      year={year}
+      month={month}
+      week={week}
+      isFirstWeek={isFirstWeek}
+      isLastWeek={isLastWeek}
+    >
+      {DAYS.map((dayIndex) => (
+        <Day
+          key={dayIndex}
+          renderDay={renderDay}
+          year={year}
+          month={month}
+          week={week}
+          dayIndex={dayIndex}
+        />
+      ))}
+    </CustomWeek>
+  );
+}
+
+export default memo(Week);

--- a/src/components/common/Calendar/index.ts
+++ b/src/components/common/Calendar/index.ts
@@ -1,0 +1,6 @@
+import { type RenderDay } from './Day';
+import Week, { type RenderWeek } from './Week';
+import Month, { type RenderMonth } from './Month';
+
+export { Week, Month };
+export type { RenderDay, RenderWeek, RenderMonth };

--- a/src/components/common/Calendar/index.ts
+++ b/src/components/common/Calendar/index.ts
@@ -1,6 +1,13 @@
-import { type RenderDay } from './Day';
-import Week, { type RenderWeek } from './Week';
-import Month, { type RenderMonth } from './Month';
+import { type RenderDay, type RenderDayProps } from './Day';
+import Week, { type RenderWeek, type RenderWeekProps } from './Week';
+import Month, { type RenderMonth, type RenderMonthProps } from './Month';
 
 export { Week, Month };
-export type { RenderDay, RenderWeek, RenderMonth };
+export type {
+  RenderDay,
+  RenderDayProps,
+  RenderWeek,
+  RenderWeekProps,
+  RenderMonth,
+  RenderMonthProps,
+};

--- a/src/hooks/useCalendarState.tsx
+++ b/src/hooks/useCalendarState.tsx
@@ -76,7 +76,8 @@ const CalendarDataStoreContext =
 
 /**
  * 캘린더 state context provider를 감싸주는 HOC
- * @example```
+ * @example
+ * ```
  * const Calendar = () => {
  *   const setCalendarState = useSetCalendarState();
  *   // ...
@@ -127,9 +128,13 @@ const getKeyStringFrom = (params: CalendarParams) => {
  * 캘린더 state를 사용할 수 있는 hook
  * @param params `CalendarParams`
  * @param equals Re-render가 필요없으면 `true`, 필요하면 `false` 반환. 기본값은 `shallow`
- * @example```
+ * @example
+ * ```
  * type DayInfo = { isSelected: boolean };
- * const [dayState, setDayState] = useCalendarState<DayInfo>({ type: 'day', date });
+ * const [dayState, setDayState] = useCalendarState<DayInfo>({
+ *   type: 'day',
+ *   date,
+ * });
  * ```
  */
 const useCalendarState = <Data,>(
@@ -160,10 +165,19 @@ const useCalendarState = <Data,>(
 
 /**
  * 여러 날짜의 state를 한 번에 바꿀 수 있는 유틸
- * @example```
+ * @example
+ * ```
  * type DayInfo = { isSelected: boolean };
  * const setCalendarState = useSetCalendarState<DayInfo>();
- * setCalendarState({ type: 'day', date: new Date(2023, 6, 9), newData: (prev) => ({ ...prev, isSelected: true }) });
+ * setCalendarState({
+ *   type: 'day',
+ *   date: new Date(2023, 6, 9),
+ *   newData: (prev) => ({ ...prev, isSelected: true }),
+ * }, {
+ *   type: 'day',
+ *   date: new Date(2023, 6, 10),
+ *   newData: (prev) => ({ ...prev, isSelected: false }),
+ * });
  * ```
  */
 export const useSetCalendarState = <

--- a/src/hooks/useCalendarState.tsx
+++ b/src/hooks/useCalendarState.tsx
@@ -1,0 +1,211 @@
+// 타입을 hook의 generic으로 받아오는 구조상 `any` 사용이 불가피하다고 판단
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import { createStore, useStore } from 'zustand';
+import { createContext, useCallback, useContext } from 'react';
+import { shallow } from 'zustand/shallow';
+import { getDateOfWeek } from '@/utils/date';
+
+interface DateData<T> {
+  [infoString: string]: T | undefined;
+}
+
+interface CalendarData<Day = unknown, Week = unknown, Month = unknown> {
+  day?: DateData<Day>;
+  week?: DateData<Week>;
+  month?: DateData<Month>;
+}
+
+type DayParams = {
+  type: 'day';
+  date: Date;
+};
+type WeekParams = {
+  type: 'week';
+  year: number;
+  month: number;
+  week: number;
+};
+type MonthParams = {
+  type: 'month';
+  year: number;
+  month: number;
+};
+
+export type CalendarParams = DayParams | WeekParams | MonthParams;
+
+type CalendarStoreSetStateAction<T> = T | ((prev?: T) => T);
+export type CalendarStoreDispatch<T> = (
+  type: 'day' | 'week' | 'month',
+  action: CalendarStoreSetStateAction<T>,
+) => void;
+export type CalendarStoreDispatchInfo<Day, Week, Month> =
+  | (DayParams & {
+      newData: CalendarStoreSetStateAction<Day>;
+    })
+  | (WeekParams & {
+      newData: CalendarStoreSetStateAction<Week>;
+    })
+  | (MonthParams & {
+      newData: CalendarStoreSetStateAction<Month>;
+    });
+
+const isFunction = <T,>(
+  action: CalendarStoreSetStateAction<T>,
+): action is (prev?: T) => T => typeof action === 'function';
+
+interface CalendarDataStore extends CalendarData<any, any, any> {
+  setRawData: (action: CalendarStoreSetStateAction<CalendarDataStore>) => void;
+  setData: CalendarStoreDispatch<DateData<any>>;
+}
+
+const calendarDataStore = createStore<CalendarDataStore>()((set) => ({
+  setRawData: (action) => {
+    if (isFunction(action)) {
+      set((state) => action(state));
+    } else {
+      set(action);
+    }
+  },
+  setData: (type, action) => {
+    if (isFunction(action)) {
+      set((state) => ({
+        ...state,
+        [type]: action(state[type]),
+      }));
+    } else {
+      set((state) => ({ ...state, [type]: action }));
+    }
+  },
+}));
+
+const CalendarDataStoreContext =
+  createContext<typeof calendarDataStore>(calendarDataStore);
+
+/**
+ * 캘린더 state context provider를 감싸주는 HOC
+ * @example```
+ * const Calendar = () => {
+ *   const setCalendarState = useSetCalendarState();
+ *   // ...
+ * };
+ *
+ * export default withCalendarStateProvider(Calendar);
+ * ```
+ */
+export const withCalendarStateProvider = <T extends object>(
+  WrappedComponent: (props: T) => JSX.Element,
+) => {
+  function ComponentWithCalendarStateProvider(props: T) {
+    return (
+      <CalendarDataStoreContext.Provider value={calendarDataStore}>
+        {/* eslint-disable-next-line react/jsx-props-no-spreading */}
+        <WrappedComponent {...props} />
+      </CalendarDataStoreContext.Provider>
+    );
+  }
+
+  return ComponentWithCalendarStateProvider;
+};
+
+const getKeyStringFrom = (params: CalendarParams) => {
+  switch (params.type) {
+    case 'day': {
+      const { date } = params;
+      return `${date.getFullYear()}-${date.getMonth()}-${date.getDate()}` as const;
+    }
+    case 'week': {
+      const date = getDateOfWeek(params.year, params.month, params.week, 0);
+      return `${date.getFullYear()}-${date.getMonth()}-${date.getDate()}` as const;
+    }
+    case 'month': {
+      return `${params.year}-${params.month}` as const;
+    }
+    default: {
+      throw new Error(
+        `[getStringFromCalendarParams] Unexpected Type of Params. Actual: ${
+          (params as { type?: string })?.type ?? 'undefined'
+        }`,
+      );
+    }
+  }
+};
+
+/**
+ * 캘린더 state를 사용할 수 있는 hook
+ * @param params `CalendarParams`
+ * @param equals Re-render가 필요없으면 `true`, 필요하면 `false` 반환. 기본값은 `shallow`
+ * @example```
+ * type DayInfo = { isSelected: boolean };
+ * const [dayState, setDayState] = useCalendarState<DayInfo>({ type: 'day', date });
+ * ```
+ */
+const useCalendarState = <Data,>(
+  params: CalendarParams,
+  equals: (a: Data | undefined, b: Data | undefined) => boolean = shallow,
+) => {
+  const store = useContext(CalendarDataStoreContext);
+  const keyString = getKeyStringFrom(params);
+  const data = useStore(
+    store,
+    (state) => state[params.type]?.[keyString],
+    equals,
+  );
+  const setStoreData = useStore(store, (state) => state.setData);
+
+  const setData = useCallback(
+    (action: CalendarStoreSetStateAction<Data>) => {
+      if (isFunction(action)) {
+        setStoreData(params.type, (prev) => ({
+          ...prev,
+          [keyString]: action(prev?.[keyString]),
+        }));
+      }
+    },
+    [keyString, params.type, setStoreData],
+  );
+
+  return [data, setData] as const;
+};
+
+/**
+ * 여러 날짜의 state를 한 번에 바꿀 수 있는 유틸
+ * @example```
+ * type DayInfo = { isSelected: boolean };
+ * const setCalendarState = useSetCalendarState<DayInfo>();
+ * setCalendarState({ type: 'day', date: new Date(2023, 6, 9), newData: (prev) => ({ ...prev, isSelected: true }) });
+ * ```
+ */
+export const useSetCalendarState = <
+  Day = unknown,
+  Week = unknown,
+  Month = unknown,
+>() => {
+  const store = useContext(CalendarDataStoreContext);
+  const setRawStoreData = useStore(store, (state) => state.setRawData);
+
+  const setMultipleData = useCallback(
+    (...dispatchInfoList: CalendarStoreDispatchInfo<Day, Week, Month>[]) => {
+      setRawStoreData((prevState) =>
+        dispatchInfoList.reduce((prev, cur) => {
+          const { newData, ...params } = cur;
+
+          return {
+            ...prev,
+            [params.type]: {
+              ...prev[params.type],
+              [getKeyStringFrom(params)]: isFunction<any>(newData)
+                ? newData(prev[params.type]?.[getKeyStringFrom(params)])
+                : newData,
+            },
+          };
+        }, prevState ?? ({} as CalendarDataStore)),
+      );
+    },
+    [setRawStoreData],
+  );
+
+  return setMultipleData;
+};
+
+export default useCalendarState;

--- a/src/hooks/useCalendarState.tsx
+++ b/src/hooks/useCalendarState.tsx
@@ -61,21 +61,13 @@ interface CalendarDataStore extends CalendarData<any, any, any> {
 
 const calendarDataStore = createStore<CalendarDataStore>()((set) => ({
   setRawData: (action) => {
-    if (isFunction(action)) {
-      set((state) => action(state));
-    } else {
-      set(action);
-    }
+    set((state) => (isFunction(action) ? action(state) : action));
   },
   setData: (type, action) => {
-    if (isFunction(action)) {
-      set((state) => ({
-        ...state,
-        [type]: action(state[type]),
-      }));
-    } else {
-      set((state) => ({ ...state, [type]: action }));
-    }
+    set((state) => ({
+      ...state,
+      [type]: isFunction(action) ? action(state[type]) : action,
+    }));
   },
 }));
 
@@ -155,12 +147,10 @@ const useCalendarState = <Data,>(
 
   const setData = useCallback(
     (action: CalendarStoreSetStateAction<Data>) => {
-      if (isFunction(action)) {
-        setStoreData(params.type, (prev) => ({
-          ...prev,
-          [keyString]: action(prev?.[keyString]),
-        }));
-      }
+      setStoreData(params.type, (prev) => ({
+        ...prev,
+        [keyString]: isFunction(action) ? action(prev?.[keyString]) : action,
+      }));
     },
     [keyString, params.type, setStoreData],
   );

--- a/src/pages/test/index.ts
+++ b/src/pages/test/index.ts
@@ -1,3 +1,3 @@
-import Test from '@/components/common';
+import Test from '@/components/common/Test';
 
 export default Test;

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -1,12 +1,12 @@
 /**
  * 특정 주의 특정 요일에 해당하는 일자를 얻는 함수
  * @example```
- * const date = getFirstDateOfWeek(2023, 6, 0, 0);
+ * const date = getDateOfWeek(2023, 6, 0, 0);
  * console.log(`${date.getFullYear()} ${date.getMonth()} ${date.getDate()}`); // 2023 05 25
  * ```
  * @param year 연도(4자리 full year)
  * @param month 달(0~11)
- * @param week 주(0~5), overflow 가능
+ * @param week 주(0~5), 범위를 벗어나도 정상 작동 (ex: 2023, 6, 6, 0 -> 2023-08-06)
  * @param dayIndex 요일(0~6)
  */
 export const getDateOfWeek = (

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -1,6 +1,7 @@
 /**
  * 특정 주의 특정 요일에 해당하는 일자를 얻는 함수
- * @example```
+ * @example
+ * ```
  * const date = getDateOfWeek(2023, 6, 0, 0);
  * console.log(`${date.getFullYear()} ${date.getMonth()} ${date.getDate()}`); // 2023 05 25
  * ```

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -1,0 +1,28 @@
+/**
+ * 특정 주의 첫 번째(일요일) 일자를 얻는 함수
+ * @example```
+ * const date = getFirstDateOfWeek(2023, 6, 0);
+ * console.log(`${date.getFullYear()} ${date.getMonth()} ${date.getDate()}`); // 2023 05 25
+ * ```
+ * @param year 연도(4자리 full year)
+ * @param month 달(0~11)
+ * @param week 주(0~5), overflow 가능
+ * @param dayIndex 요일(0~6)
+ */
+export const getDateOfWeek = (
+  year: number,
+  month: number,
+  week: number,
+  dayIndex: number,
+) => {
+  const firstDateOfMonth = new Date(year, month, 1, 15, 0, 0, 0);
+  return new Date(
+    year,
+    month,
+    1 + week * 7 - firstDateOfMonth.getDay() + dayIndex,
+    15,
+    0,
+    0,
+    0,
+  );
+};

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -1,7 +1,7 @@
 /**
- * 특정 주의 첫 번째(일요일) 일자를 얻는 함수
+ * 특정 주의 특정 요일에 해당하는 일자를 얻는 함수
  * @example```
- * const date = getFirstDateOfWeek(2023, 6, 0);
+ * const date = getFirstDateOfWeek(2023, 6, 0, 0);
  * console.log(`${date.getFullYear()} ${date.getMonth()} ${date.getDate()}`); // 2023 05 25
  * ```
  * @param year 연도(4자리 full year)


### PR DESCRIPTION
## 🔗 Issue Number
resolves #3 

## 📄 Description
- `Week`, `Month` 컴포넌트를 구현했습니다.
- 캘린더 UI를 컨트롤하기 위한 상태 관리 유틸 `useCalendarState`, `useSetCalendarState`, `withCalendarStateProvider`를 구현했습니다.
- `pages/test/index.ts`의 잘못된 경로를 수정했습니다.

명세가 조금 특이한데, 스토리북을 참고해 주시고 빠른 시일 내에 Notion 문서화도 진행할게요!

## ✅ Checklist

- [x] PR 제목을 commit 규칙에 맞게 작성했나요?
- [x] label을 설정했나요?
- [x] 작업한 사람 모두를 Assign 했나요?
- [x] Code Review를 요청 했나요?
