### PR TITLE
feat: add date select step in newHangoutTab

### DIFF
--- a/src/components/common/Calendar/MontlyCalendar.tsx
+++ b/src/components/common/Calendar/MontlyCalendar.tsx
@@ -12,16 +12,17 @@ import * as styles from './Calendar.css';
 
 export const DAY_OF_WEEKS = ['일', '월', '화', '수', '목', '금', '토'] as const;
 
-interface MontlyCProps {
+interface MontlyCalendarProps {
   year: number;
   /** 0~11 */
   month: number;
+  onSelectDay?: (day: Date) => void;
 }
 
 /**
  * 월간 캘린더 컴포넌트
  */
-const MontlyCalendar = ({ year, month }: MontlyCProps) => {
+const MontlyCalendar = ({ year, month, onSelectDay }: MontlyCalendarProps) => {
   const selectedDayRef = useRef<Date | null>(null);
 
   const renderMonth: RenderMonth = useCallback(
@@ -51,9 +52,13 @@ const MontlyCalendar = ({ year, month }: MontlyCProps) => {
 
   const renderDay = useCallback(
     (renderDayProps: RenderDayProps) => (
-      <StyledDay {...renderDayProps} selectedDayRef={selectedDayRef} />
+      <StyledDay
+        {...renderDayProps}
+        selectedDayRef={selectedDayRef}
+        selectedDayHandler={onSelectDay}
+      />
     ),
-    [],
+    [onSelectDay],
   );
 
   return (

--- a/src/components/common/Calendar/StyledDay.tsx
+++ b/src/components/common/Calendar/StyledDay.tsx
@@ -33,9 +33,10 @@ const StyledDay = ({
       setDayState((prev) => ({ ...prev, isSelected: true }));
       selectedDayRef.current = date;
       selectedDayHandler?.(selectedDayRef.current);
+      return;
     }
     // 선택되어 있는 날짜를 눌러서 해제하는 경우
-    else if (isSameDate(selectedDayRef.current, date)) {
+    if (isSameDate(selectedDayRef.current, date)) {
       setDayState((prev) => ({ ...prev, isSelected: false }));
       selectedDayRef.current = null;
     }

--- a/src/components/common/Calendar/StyledDay.tsx
+++ b/src/components/common/Calendar/StyledDay.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-param-reassign */
 import { MutableRefObject } from 'react';
 import useCalendarState, {
   useSetCalendarState,
@@ -11,9 +12,15 @@ type DayInfo = { isSelected: boolean };
 
 interface DayProps extends RenderDayProps {
   selectedDayRef: MutableRefObject<Date | null>;
+  selectedDayHandler?: (day: Date) => void;
 }
 
-const StyledDay = ({ date, isInCurrentMonth, selectedDayRef }: DayProps) => {
+const StyledDay = ({
+  date,
+  isInCurrentMonth,
+  selectedDayRef,
+  selectedDayHandler,
+}: DayProps) => {
   const [dayState, setDayState] = useCalendarState<DayInfo>({
     type: 'day',
     date,
@@ -21,15 +28,19 @@ const StyledDay = ({ date, isInCurrentMonth, selectedDayRef }: DayProps) => {
   const setCalendarState = useSetCalendarState<DayInfo>();
 
   const onClickDay = () => {
+    // 어떤 날짜도 선택되어 있지 않은 상태인 경우
     if (selectedDayRef.current === null) {
       setDayState((prev) => ({ ...prev, isSelected: true }));
-      // eslint-disable-next-line no-param-reassign
       selectedDayRef.current = date;
-    } else if (isSameDate(selectedDayRef.current, date)) {
+      selectedDayHandler?.(selectedDayRef.current);
+    }
+    // 선택되어 있는 날짜를 눌러서 해제하는 경우
+    else if (isSameDate(selectedDayRef.current, date)) {
       setDayState((prev) => ({ ...prev, isSelected: false }));
-      // eslint-disable-next-line no-param-reassign
       selectedDayRef.current = null;
-    } else {
+    }
+    // 현재 선택된 날짜와 다른 날짜를 누른 경우
+    else {
       setCalendarState(
         {
           type: 'day',
@@ -42,8 +53,8 @@ const StyledDay = ({ date, isInCurrentMonth, selectedDayRef }: DayProps) => {
           newData: (prev) => ({ ...prev, isSelected: true }),
         },
       );
-      // eslint-disable-next-line no-param-reassign
       selectedDayRef.current = date;
+      selectedDayHandler?.(selectedDayRef.current);
     }
   };
 

--- a/src/components/friend/schedule/FriendScheduleContent/ScheduleList/ScheduleList.tsx
+++ b/src/components/friend/schedule/FriendScheduleContent/ScheduleList/ScheduleList.tsx
@@ -1,35 +1,13 @@
-import { useState } from 'react';
 import HangoutBox from '@/components/common/HangoutBox';
 import { CalenderHeader, MontlyCalendar } from '@/components/common/Calendar';
+import useMontlyCalendar from '@/hooks/useMontlyCalendar';
 import * as styles from '../FriendScheduleContent.css';
 
 import { hangoutsDummydata } from '@/dummyData';
 
-const today = new Date();
-
 // TODO  hangout dummydata 교체
 const ScheduleList = () => {
-  const [currentDate, setCurrentDate] = useState({
-    year: today.getFullYear(),
-    month: today.getMonth(),
-  });
-  const { year, month } = currentDate;
-
-  const setBeforeMonth = () => {
-    setCurrentDate((prev) => ({
-      ...prev,
-      year: month === 0 ? prev.year - 1 : prev.year,
-      month: month === 0 ? 11 : prev.month - 1,
-    }));
-  };
-
-  const setNextMonth = () => {
-    setCurrentDate((prev) => ({
-      ...prev,
-      year: month === 11 ? prev.year + 1 : prev.year,
-      month: month === 11 ? 0 : prev.month + 1,
-    }));
-  };
+  const { year, month, setBeforeMonth, setNextMonth } = useMontlyCalendar();
 
   const hangout = hangoutsDummydata[0];
 

--- a/src/components/home/HomeContent/ScheduleList/ScheduleList.tsx
+++ b/src/components/home/HomeContent/ScheduleList/ScheduleList.tsx
@@ -1,36 +1,14 @@
-import { useState } from 'react';
 import ContentBox from '@/components/common/ContentBox';
 import HangoutBox from '@/components/common/HangoutBox';
 import { CalenderHeader, MontlyCalendar } from '@/components/common/Calendar';
+import useMontlyCalendar from '@/hooks/useMontlyCalendar';
 import * as styles from '../HomeContent.css';
 
 import { hangoutsDummydata } from '@/dummyData';
 
 // TODO  hangout dummydata 교체
 const ScheduleList = () => {
-  const today = new Date();
-
-  const [currentDate, setCurrentDate] = useState({
-    year: today.getFullYear(),
-    month: today.getMonth(),
-  });
-  const { year, month } = currentDate;
-
-  const setBeforeMonth = () => {
-    setCurrentDate((prev) => ({
-      ...prev,
-      year: month === 0 ? prev.year - 1 : prev.year,
-      month: month === 0 ? 11 : prev.month - 1,
-    }));
-  };
-
-  const setNextMonth = () => {
-    setCurrentDate((prev) => ({
-      ...prev,
-      year: month === 11 ? prev.year + 1 : prev.year,
-      month: month === 11 ? 0 : prev.month + 1,
-    }));
-  };
+  const { year, month, setBeforeMonth, setNextMonth } = useMontlyCalendar();
 
   return (
     <ContentBox

--- a/src/components/newHangout/NewHangoutContent/SelectDateStep/DateSelectBox.tsx
+++ b/src/components/newHangout/NewHangoutContent/SelectDateStep/DateSelectBox.tsx
@@ -1,0 +1,70 @@
+import CheckBox from '@/components/common/CheckBox';
+import { getDateTimeLocalString } from '@/utils/date';
+
+import * as styles from './SelectDateStep.css';
+import { ScheduleType } from '@/types/schedule';
+
+interface DateSelectBoxProps {
+  infoVer: boolean;
+  setInfoVer: React.Dispatch<React.SetStateAction<boolean>>;
+  selectedSchedule: ScheduleType | null;
+  setSelectedSchedule: React.Dispatch<
+    React.SetStateAction<ScheduleType | null>
+  >;
+}
+
+const DateSelectBox = ({
+  infoVer,
+  setInfoVer,
+  selectedSchedule,
+  setSelectedSchedule,
+}: DateSelectBoxProps) => {
+  const onClickCheckbox = () => setInfoVer((prev) => !prev);
+
+  const onChangeDate = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { name, value } = e.target;
+    setSelectedSchedule(
+      (prev) => ({ ...prev, [name]: new Date(value) } as ScheduleType),
+    );
+  };
+
+  return (
+    <div className={styles.selectBoxWrapper}>
+      <div className={styles.checkboxWrap}>
+        <CheckBox checked={infoVer} onClick={onClickCheckbox} />
+        <div className={styles.checkboxLabel}>멤버 일정 보기</div>
+      </div>
+      <div className={styles.dateInputsWrap}>
+        <div>
+          <div className={styles.dateLabel}>시작</div>
+          <input
+            type="datetime-local"
+            name="start"
+            value={
+              selectedSchedule
+                ? getDateTimeLocalString(selectedSchedule.start)
+                : ''
+            }
+            onChange={onChangeDate}
+            className={styles.dateInput}
+          />
+        </div>
+        <div>
+          <div className={styles.dateLabel}>종료</div>
+          <input
+            type="datetime-local"
+            name="end"
+            value={
+              selectedSchedule
+                ? getDateTimeLocalString(selectedSchedule.end)
+                : ''
+            }
+            className={styles.dateInput}
+          />
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default DateSelectBox;

--- a/src/components/newHangout/NewHangoutContent/SelectDateStep/SelectDateStep.css.ts
+++ b/src/components/newHangout/NewHangoutContent/SelectDateStep/SelectDateStep.css.ts
@@ -1,0 +1,74 @@
+import { style } from '@vanilla-extract/css';
+import { COLORS, TEXT_STYLES } from '@/constants/styles';
+
+export const calendarHeader = style({
+  justifyContent: 'center',
+  marginBottom: '20px',
+});
+
+export const scheduleListWrapper = style({
+  width: '100%',
+  marginTop: '25px',
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '8px',
+});
+
+export const scheduleBox = style({
+  ...TEXT_STYLES.body2R,
+  backgroundColor: COLORS.grayscale.white,
+  borderRadius: '8px',
+  boxShadow: '0px 0px 3px 0px rgba(85, 85, 85, 0.25)',
+  width: '100%',
+  height: '45px',
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+});
+
+export const selectedSchedule = style({
+  backgroundColor: COLORS.grayscale.gray100,
+});
+
+export const selectBoxWrapper = style({
+  display: 'flex',
+  flexDirection: 'column',
+  justifyContent: 'flex-start',
+  position: 'fixed',
+  left: '0px',
+  bottom: '0px',
+  padding: '20px 10px 96px',
+  width: '100%',
+  backgroundColor: COLORS.grayscale.white,
+  boxShadow: '0px -2px 20px 0px rgba(187, 187, 187, 0.25)',
+});
+
+export const checkboxLabel = style({
+  ...TEXT_STYLES.body2B,
+  color: COLORS.grayscale.gray800,
+});
+
+export const checkboxWrap = style({
+  display: 'flex',
+  alignItems: 'center',
+  gap: '8px',
+});
+
+export const dateInputsWrap = style({
+  display: 'flex',
+  justifyContent: 'space-between',
+  marginTop: '14px',
+});
+
+export const dateLabel = style({
+  ...TEXT_STYLES.body2B,
+  color: COLORS.grayscale.gray700,
+});
+
+export const dateInput = style({
+  border: 'none',
+  borderRadius: '4px',
+  backgroundColor: COLORS.grayscale.gray100,
+  padding: '4px 0px 4px 12px',
+  marginTop: '4px',
+});

--- a/src/components/newHangout/NewHangoutContent/SelectDateStep/SelectDateStep.tsx
+++ b/src/components/newHangout/NewHangoutContent/SelectDateStep/SelectDateStep.tsx
@@ -1,14 +1,84 @@
+import { useCallback, useState } from 'react';
+import { CalenderHeader, MontlyCalendar } from '@/components/common/Calendar';
+import { getHourAndMinute, isSameDate } from '@/utils/date';
+import { ScheduleType } from '@/types/schedule';
+import useMontlyCalendar from '@/hooks/useMontlyCalendar';
+import DateSelectBox from './DateSelectBox';
+import * as styles from './SelectDateStep.css';
+
+const DummySchedules = [
+  { start: new Date('2023-08-26T15:30'), end: new Date('2023-08-26T19:00') },
+  { start: new Date('2023-08-27T15:30'), end: new Date('2023-08-27T19:00') },
+  { start: new Date('2023-08-27T20:30'), end: new Date('2023-08-27T24:00') },
+  { start: new Date('2023-09-01T12:30'), end: new Date('2023-09-27T24:00') },
+];
+
 interface SelectDateStepProps {
   setValid: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
-const SelectDateStep = ({ setValid }: SelectDateStepProps) => (
-  <>
-    <div>날짜 선택 단계</div>
-    <button type="button" onClick={() => setValid(true)}>
-      일단 했다 생각해
-    </button>
-  </>
-);
+const SelectDateStep = ({ setValid }: SelectDateStepProps) => {
+  const { year, month, setBeforeMonth, setNextMonth } = useMontlyCalendar();
+
+  // 멤버 일정 보기 유무
+  const [infoVer, setInfoVer] = useState<boolean>(false);
+  // 선택된 날짜 내 가능한 스케줄 리스트
+  const [filteredSchedules, setFilteredSchedules] = useState<ScheduleType[]>(
+    [],
+  );
+  // 현재 선택된 스케줄
+  const [selectedSchedule, setSelectedSchedule] = useState<ScheduleType | null>(
+    null,
+  );
+
+  const onSelectDay = useCallback((day: Date) => {
+    setFilteredSchedules(
+      DummySchedules.filter((schedule) => isSameDate(schedule.start, day)),
+    );
+  }, []);
+
+  const onSelectSchedule = (schedule: ScheduleType) => {
+    setSelectedSchedule(schedule);
+    setValid(true);
+  };
+
+  return (
+    <>
+      <CalenderHeader
+        year={year}
+        month={month}
+        goBefore={setBeforeMonth}
+        goNext={setNextMonth}
+        className={styles.calendarHeader}
+      />
+      <MontlyCalendar year={year} month={month} onSelectDay={onSelectDay} />
+      <div className={styles.scheduleListWrapper}>
+        {infoVer ? (
+          <>멤버 일정</>
+        ) : (
+          filteredSchedules.map((schedule) => (
+            <div
+              key={schedule.start.toString()}
+              className={`${styles.scheduleBox} ${
+                schedule === selectedSchedule && styles.selectedSchedule
+              }`}
+              onClick={() => onSelectSchedule(schedule)}
+            >
+              {`${getHourAndMinute(schedule.start)} - ${getHourAndMinute(
+                schedule.end,
+              )}`}
+            </div>
+          ))
+        )}
+      </div>
+      <DateSelectBox
+        infoVer={infoVer}
+        setInfoVer={setInfoVer}
+        selectedSchedule={selectedSchedule}
+        setSelectedSchedule={setSelectedSchedule}
+      />
+    </>
+  );
+};
 
 export default SelectDateStep;

--- a/src/hooks/useMontlyCalendar.tsx
+++ b/src/hooks/useMontlyCalendar.tsx
@@ -1,0 +1,34 @@
+import { useState } from 'react';
+
+const useMontlyCalendar = () => {
+  const today = new Date();
+
+  // 현재 캘린더에서 보여지고 있는 연도 및 월
+  const [currentDate, setCurrentDate] = useState({
+    year: today.getFullYear(),
+    month: today.getMonth(),
+  });
+  const { year, month } = currentDate;
+
+  const setBeforeMonth = () => {
+    setCurrentDate((prev) => ({
+      ...prev,
+      year: month === 0 ? prev.year - 1 : prev.year,
+      month: month === 0 ? 11 : prev.month - 1,
+      day: -1,
+    }));
+  };
+
+  const setNextMonth = () => {
+    setCurrentDate((prev) => ({
+      ...prev,
+      year: month === 11 ? prev.year + 1 : prev.year,
+      month: month === 11 ? 0 : prev.month + 1,
+      day: -1,
+    }));
+  };
+
+  return { year, month, setBeforeMonth, setNextMonth };
+};
+
+export default useMontlyCalendar;

--- a/src/hooks/useMontlyCalendar.tsx
+++ b/src/hooks/useMontlyCalendar.tsx
@@ -1,5 +1,12 @@
 import { useState } from 'react';
 
+/**
+ * 월 캘린더를 사용하기 위한 훅 함수
+ * @returns year 현재 년도
+ * @returns month 현재 월
+ * @returns setBeforeMonth 캘린더에서 이전 달을 보기 위한 함수
+ * @returns setNextMonth 캘린더에서 다음 달을 보기 위한 함수
+ */
 const useMontlyCalendar = () => {
   const today = new Date();
 

--- a/src/hooks/useMontlyCalendar.tsx
+++ b/src/hooks/useMontlyCalendar.tsx
@@ -22,7 +22,6 @@ const useMontlyCalendar = () => {
       ...prev,
       year: month === 0 ? prev.year - 1 : prev.year,
       month: month === 0 ? 11 : prev.month - 1,
-      day: -1,
     }));
   };
 
@@ -31,7 +30,6 @@ const useMontlyCalendar = () => {
       ...prev,
       year: month === 11 ? prev.year + 1 : prev.year,
       month: month === 11 ? 0 : prev.month + 1,
-      day: -1,
     }));
   };
 

--- a/src/types/schedule.ts
+++ b/src/types/schedule.ts
@@ -1,0 +1,4 @@
+export interface ScheduleType {
+  start: Date;
+  end: Date;
+}

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -53,6 +53,7 @@ export function getMonthAndDay(date: Date) {
 }
 
 /**
+ * date를 `<input type="datetieme-local" />`의 value로 사용하기 위한 함수
  * @returns `YYYY-MM-DDThh:mm:ss`
  */
 export function getDateTimeLocalString(date: Date) {
@@ -61,7 +62,10 @@ export function getDateTimeLocalString(date: Date) {
   return localDate.toISOString().split('.')[0];
 }
 
-/** 2개의 날짜가 같은 날짜인지 확인하는 함수 */
+/**
+ * 2개의 날짜가 같은 날짜인지 확인하는 함수
+ * @returns 두 날짜가 같은 날짜인지 여부 boolean
+ */
 export function isSameDate(date1: Date, date2: Date) {
   return (
     date1.getFullYear() === date2.getFullYear() &&

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -41,7 +41,8 @@ export function getDday(date: Date) {
  * @returns `h시 m분`
  */
 export function getHourAndMinute(date: Date) {
-  return `${date.getHours()}시 ${date.getMinutes()}분`;
+  const hour = date.getHours() === 0 ? 24 : date.getHours();
+  return `${hour}시 ${date.getMinutes()}분`;
 }
 
 /**
@@ -51,6 +52,14 @@ export function getMonthAndDay(date: Date) {
   return `${date.getMonth() + 1}월 ${date.getDate()}일`;
 }
 
+/**
+ * @returns `YYYY-MM-DDThh:mm:ss`
+ */
+export function getDateTimeLocalString(date: Date) {
+  const offset = date.getTimezoneOffset() * 60000;
+  const localDate = new Date((date as any) - offset);
+  return localDate.toISOString().split('.')[0];
+}
 
 /** 2개의 날짜가 같은 날짜인지 확인하는 함수 */
 export function isSameDate(date1: Date, date2: Date) {


### PR DESCRIPTION
## 🔗 Issue Number
#32 
## 📄 Description
- 약속 만들기 플로우 중 '시간 선택' 단계 페이지 작업을 진행했습니다.
- 기존에는 `MonltyCalendar`를 사용하는 컴포넌트에서 현재 연도와 월, 이전달/다음달로 이동하는 함수를 각각 생성하는 방식이었는데, 이를 `useMontlyCalendar` 훅 함수로 뺐어요!
문제가 있으면 알려주십셔 감사합니당
## ✅ Checklist

- [X] PR 제목을 commit 규칙에 맞게 작성했나요?
- [X] label을 설정했나요?
- [X] 작업한 사람 모두를 Assign 했나요?
- [X] Code Review를 요청 했나요?
